### PR TITLE
bug: fix charts fontsize bug in firefox

### DIFF
--- a/src/plugins/inner/ThemePlugin.js
+++ b/src/plugins/inner/ThemePlugin.js
@@ -46,8 +46,8 @@ class ThemePlugin {
                 const disabledColors = colors.map(c => [...c, disabledOpacity]);
                 const fadeColors = colors.map(c => [...c, fadeOpacity]);
                 const font = getComputedStyle(container).font;
-                const fontSize = parseFloat(font);
-
+                const fontSizeRegResult = /\d{1,3}px/.exec(font);
+                const fontSize = parseFloat(fontSizeRegResult[0]);
                 globalCtx.theme = {
                     getColor(idx) {
                         const i = idx % length;


### PR DESCRIPTION
修复在火狐浏览器下图表的字体样式错误的问题 @wt911122 